### PR TITLE
Prevent client from setting message timestamps

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -4,17 +4,18 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"in-terminal-chat/internal/chat"
 	"os"
 	"strings"
 	"time"
+
+	"in-terminal-chat/internal/chat"
 
 	"github.com/TwiN/go-color"
 	"github.com/gorilla/websocket"
 	"github.com/gosuri/uilive"
 )
 
-const messagePattern = "[%s] %s -> %s"
+const messageFmt = "[%s] %s -> %s"
 
 func main() {
 	address := flag.String("address", "ws://localhost:8080", "http service address")
@@ -46,7 +47,7 @@ func writeMessage(c *websocket.Conn, name string) {
 			continue
 		}
 
-		if err := c.WriteJSON(chat.BuildMessage(name, message, time.Now().Unix())); err != nil {
+		if err := c.WriteJSON(chat.Message{Owner: name, Text: message}); err != nil {
 			fmt.Printf("Failed to send message: %v\n", err)
 			break
 		}
@@ -73,7 +74,7 @@ func readMessages(c *websocket.Conn, name string) {
 }
 
 func assembleMessage(m chat.Message) string {
-	return fmt.Sprintf(messagePattern, time.Unix(m.UnixTimestamp, 0), m.Owner, m.Text)
+	return fmt.Sprintf(messageFmt, time.Unix(m.UnixTimestamp, 0), m.Owner, m.Text)
 }
 
 func makeDialURL(address *string, name *string) string {

--- a/internal/chat/hub.go
+++ b/internal/chat/hub.go
@@ -48,6 +48,7 @@ func (h hub) Run() {
 			}
 
 		case message := <-h.broadcast:
+			message.UnixTimestamp = time.Now().Unix()
 			logrus.WithField("message", message).Debug("Message received")
 			for c := range h.clients {
 				select {

--- a/internal/chat/message.go
+++ b/internal/chat/message.go
@@ -1,8 +1,8 @@
 package chat
 
 const (
-	joinChatMessage           = "*join the chat*"
-	disconnectFromChatMessage = "*disconnect from the chat*"
+	messageJoined       = "*joined the chat*"
+	messageDisconnected = "*disconnected from the chat*"
 )
 
 type Message struct {
@@ -15,9 +15,9 @@ func BuildMessage(name, text string, unixTimestamp int64) Message {
 }
 
 func BuildJoinMessage(name string, unixTimestamp int64) Message {
-	return BuildMessage(name, joinChatMessage, unixTimestamp)
+	return BuildMessage(name, messageJoined, unixTimestamp)
 }
 
 func BuildDisconnectMessage(name string, unixTimestamp int64) Message {
-	return BuildMessage(name, disconnectFromChatMessage, unixTimestamp)
+	return BuildMessage(name, messageDisconnected, unixTimestamp)
 }

--- a/internal/chat/message_test.go
+++ b/internal/chat/message_test.go
@@ -33,15 +33,15 @@ func (s *MessageTestSuite) TestBuildMessage() {
 }
 
 func (s *MessageTestSuite) TestBuildJoinMessage() {
-	expected := Message{Owner: s.name, Text: joinChatMessage, UnixTimestamp: s.unixTimestamp}
-	actual := BuildMessage(s.name, joinChatMessage, s.unixTimestamp)
+	expected := Message{Owner: s.name, Text: messageJoined, UnixTimestamp: s.unixTimestamp}
+	actual := BuildMessage(s.name, messageJoined, s.unixTimestamp)
 
 	s.Equal(expected, actual)
 }
 
 func (s *MessageTestSuite) TestBuildDisconnectMessage() {
-	expected := Message{Owner: s.name, Text: disconnectFromChatMessage, UnixTimestamp: s.unixTimestamp}
-	actual := BuildMessage(s.name, disconnectFromChatMessage, s.unixTimestamp)
+	expected := Message{Owner: s.name, Text: messageDisconnected, UnixTimestamp: s.unixTimestamp}
+	actual := BuildMessage(s.name, messageDisconnected, s.unixTimestamp)
 
 	s.Equal(expected, actual)
 }


### PR DESCRIPTION
- Prevents clients from setting custom message timestamps (override in server)
- Refactored constant names